### PR TITLE
Collecting all Astraea-specific build overrides into a separate sbt file.

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -40,15 +40,7 @@ object ProjectPlugin extends AutoPlugin {
     rfSparkVersion in ThisBuild := "2.3.2" ,
     rfGeoTrellisVersion in ThisBuild := "2.1.0",
     rfGeoMesaVersion in ThisBuild := "2.1.0",
-
-    credentials += Credentials(Path.userHome / ".sbt" / ".credentials"),
-    publishTo := {
-      val base = "https://s22s.mycloudrepo.io/repositories"
-      if (isSnapshot.value)
-        Some("Astraea Internal Snapshots" at s"$base/snapshots/")
-      else
-        Some("Astraea Internal Releases" at s"$base/releases/")
-    },
+    publishTo := sonatypePublishTo.value,
     publishMavenStyle := true,
     publishArtifact in (Compile, packageDoc) := true,
     publishArtifact in Test := false,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.0-astraea-SNAPSHOT"
+version in ThisBuild := "0.8.0-SNAPSHOT"

--- a/x-astraea.sbt
+++ b/x-astraea.sbt
@@ -1,0 +1,10 @@
+// Internal Astraea-specific overides
+version in ThisBuild := "0.8.0-astraea-SNAPSHOT"
+credentials in ThisBuild += Credentials(Path.userHome / ".sbt" / ".credentials")
+publishTo := {
+  val base = "https://s22s.mycloudrepo.io/repositories"
+  if (isSnapshot.value)
+    Some("Astraea Internal Snapshots" at s"$base/snapshots/")
+  else
+    Some("Astraea Internal Releases" at s"$base/releases/")
+}


### PR DESCRIPTION
Due to sbt evaluating build scripts in alphabetical order we can use a `x-` prefix for the filename and ensure the settings in it take precedence over the standard settings, while still maintaining synchronization/parity with the standard branches.