### PR TITLE
Added ability to use a RasterSourceRelation against a table/view of paths.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ _defaults: &defaults
   environment:
     TERM: dumb
   docker:
-    - image: circleci/openjdk:8-jdk
-
+    - image: s22s/rasterframes-circleci:latest
+      
 _setenv: &setenv
   name: set CloudRepo credentials
   command: |-

--- a/bench/src/main/scala/org/locationtech/rasterframes/bench/RasterRefBench.scala
+++ b/bench/src/main/scala/org/locationtech/rasterframes/bench/RasterRefBench.scala
@@ -19,14 +19,13 @@
  *
  */
 
-package astraea.spark.rasterframes.bench
-
+package org.locationtech.rasterframes.bench
 
 import java.util.concurrent.TimeUnit
 
-import astraea.spark.rasterframes._
-import astraea.spark.rasterframes.expressions.transformers.RasterSourceToTiles
-import astraea.spark.rasterframes.ref.RasterSource
+import org.locationtech.rasterframes._
+import org.locationtech.rasterframes.expressions.transformers.RasterSourceToTiles
+import org.locationtech.rasterframes.ref.RasterSource
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql._
 import org.openjdk.jmh.annotations._

--- a/bench/src/main/scala/org/locationtech/rasterframes/bench/package.scala
+++ b/bench/src/main/scala/org/locationtech/rasterframes/bench/package.scala
@@ -29,7 +29,7 @@ import geotrellis.raster.{ArrayTile, CellType, NODATA, Tile, isNoData}
  * @author sfitch 
  * @since 10/4/17
  */
-package object rasterframes {
+package object bench {
   val rnd = new scala.util.Random(42)
 
   /** Construct a tile of given size and cell type populated with random values. */

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/RasterSourceToTiles.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/RasterSourceToTiles.scala
@@ -40,6 +40,7 @@ import org.locationtech.rasterframes.TileType
  *
  * @since 9/6/18
  */
+@deprecated("Use RasterSourceToRasterRefs and RasterRef to Tile instread", "4/28/19")
 case class RasterSourceToTiles(children: Seq[Expression], applyTiling: Boolean) extends Expression
   with Generator with CodegenFallback with ExpectsInputTypes with LazyLogging {
 
@@ -74,7 +75,9 @@ case class RasterSourceToTiles(children: Seq[Expression], applyTiling: Boolean) 
 
 
 object RasterSourceToTiles {
+  @deprecated("Use RasterSourceToRasterRefs and RasterRef to Tile instread", "4/28/19")
   def apply(rrs: Column*): Column = apply(true, rrs: _*)
+  @deprecated("Use RasterSourceToRasterRefs and RasterRef to Tile instread", "4/28/19")
   def apply(applyTiling: Boolean, rrs: Column*): Column =
     new Column(new RasterSourceToTiles(rrs.map(_.expr), applyTiling))
 }

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/URIToRasterSource.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/URIToRasterSource.scala
@@ -23,7 +23,6 @@ package org.locationtech.rasterframes.expressions.transformers
 
 import java.net.URI
 
-import org.locationtech.rasterframes.ref.RasterRef
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, UnaryExpression}
@@ -31,7 +30,7 @@ import org.apache.spark.sql.rf._
 import org.apache.spark.sql.types.{DataType, StringType}
 import org.apache.spark.sql.{Column, TypedColumn}
 import org.apache.spark.unsafe.types.UTF8String
-import org.locationtech.rasterframes.ref.{RasterRef, RasterSource}
+import org.locationtech.rasterframes.ref.RasterSource
 
 
 /**
@@ -58,6 +57,6 @@ case class URIToRasterSource(override val child: Expression)
 }
 
 object URIToRasterSource {
-  def apply(rasterURI: Column): TypedColumn[Any, RasterRef] =
-    new Column(new URIToRasterSource(rasterURI.expr)).as[RasterRef]
+  def apply(rasterURI: Column): TypedColumn[Any, RasterSource] =
+    new Column(new URIToRasterSource(rasterURI.expr)).as[RasterSource]
 }

--- a/core/src/main/scala/org/locationtech/rasterframes/util/package.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/util/package.scala
@@ -32,7 +32,8 @@ import geotrellis.raster.{CellGrid, Tile, isNoData}
 import geotrellis.spark.Bounds
 import geotrellis.spark.tiling.TilerKeyMethods
 import geotrellis.util.{ByteReader, GetComponent}
-import org.apache.spark.sql.catalyst.expressions.{Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.rf._
@@ -103,7 +104,9 @@ package object util {
   implicit class ExpressionWithName(val expr: Expression) extends AnyVal {
     import org.apache.spark.sql.catalyst.expressions.Literal
     def name: String = expr match {
-      case n: NamedExpression ⇒ n.name
+      case n: NamedExpression if n.resolved ⇒ n.name
+      case UnresolvedAttribute(parts) => parts.mkString("_")
+      case Alias(_, name) => name
       case l: Literal if l.dataType == StringType ⇒ String.valueOf(l.value)
       case o ⇒ o.toString
     }

--- a/core/src/test/scala/org/locationtech/rasterframes/TestData.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/TestData.scala
@@ -110,6 +110,12 @@ trait TestData {
     require((1 to 11).contains(band), "Invalid band number")
     readSingleband(s"L8-B$band-Elkton-VA.tiff")
   }
+
+  def l8SamplePath(band: Int) = {
+    require((1 to 11).contains(band), "Invalid band number")
+    getClass.getResource(s"/L8-B$band-Elkton-VA.tiff").toURI
+  }
+
   def l8Labels = readSingleband("L8-Labels-Elkton-VA.tiff")
 
   def naipSample(band: Int) = {
@@ -135,7 +141,7 @@ trait TestData {
   lazy val localSentinel: URL = getClass.getResource("/B01.jp2")
   lazy val cogPath: URI = getClass.getResource("/LC08_RGB_Norfolk_COG.tiff").toURI
   lazy val nonCogPath: URI = getClass.getResource("/L8-B8-Robinson-IL.tiff").toURI
-  lazy val l8samplePath: URI = getClass.getResource("/L8-B1-Elkton-VA.tiff").toURI
+  lazy val l8B1SamplePath: URI = l8SamplePath(1)
 
   object JTS {
     val fact = new GeometryFactory()

--- a/datasource/src/main/scala/org/locationtech/rasterframes/datasource/rastersource/RasterSourceDataSource.scala
+++ b/datasource/src/main/scala/org/locationtech/rasterframes/datasource/rastersource/RasterSourceDataSource.scala
@@ -45,10 +45,10 @@ object RasterSourceDataSource {
   final val BAND_INDEXES_PARAM = "bandIndexes"
   final val TILE_DIMS_PARAM = "tileDimensions"
   final val PATH_TABLE_PARAM = "pathTable"
-  final val PATH_TABLE_COL_PARAM = "pathTableColumn"
+  final val PATH_TABLE_COL_PARAM = "pathTableColumns"
 
   /** Container for specifying where to select raster paths from. */
-  case class PathColumn(tableName: String, columnName: String)
+  case class RasterSourceTable(tableName: String, columnNames: String*)
 
   private[rastersource]
   implicit class ParamsDictAccessors(val parameters: Map[String, String]) extends AnyVal {
@@ -73,10 +73,10 @@ object RasterSourceDataSource {
       .map(_.split(',').map(_.trim.toInt).toSeq)
       .getOrElse(Seq(0))
 
-    def pathTable: Option[PathColumn] = parameters
+    def pathTable: Option[RasterSourceTable] = parameters
       .get(PATH_TABLE_PARAM)
       .zip(parameters.get(PATH_TABLE_COL_PARAM))
-      .map(p => PathColumn(p._1, p._2))
+      .map(p => RasterSourceTable(p._1, p._2.split(','): _*))
       .headOption
   }
 }

--- a/datasource/src/main/scala/org/locationtech/rasterframes/datasource/rastersource/RasterSourceDataSource.scala
+++ b/datasource/src/main/scala/org/locationtech/rasterframes/datasource/rastersource/RasterSourceDataSource.scala
@@ -29,10 +29,13 @@ class RasterSourceDataSource extends DataSourceRegister with RelationProvider {
   import RasterSourceDataSource._
   override def shortName(): String = SHORT_NAME
   override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation = {
-    val inexes = parameters.bandIndexes
-    val files = parameters.filePaths
+    val bands = parameters.bandIndexes
     val tiling = parameters.tileDims
-    RasterSourceRelation(sqlContext, files, inexes, tiling)
+    val pathTable = parameters.pathTable
+    val files = parameters.filePaths
+    require(!(pathTable.nonEmpty && files.nonEmpty),
+      "Only one of a set of file paths OR a paths table column may be provided.")
+    RasterSourceRelation(sqlContext, files, pathTable, bands, tiling)
   }
 }
 object RasterSourceDataSource {
@@ -41,6 +44,11 @@ object RasterSourceDataSource {
   final val PATHS_PARAM = "paths"
   final val BAND_INDEXES_PARAM = "bandIndexes"
   final val TILE_DIMS_PARAM = "tileDimensions"
+  final val PATH_TABLE_PARAM = "pathTable"
+  final val PATH_TABLE_COL_PARAM = "pathTableColumn"
+
+  /** Container for specifying where to select raster paths from. */
+  case class PathColumn(tableName: String, columnName: String)
 
   private[rastersource]
   implicit class ParamsDictAccessors(val parameters: Map[String, String]) extends AnyVal {
@@ -64,5 +72,11 @@ object RasterSourceDataSource {
       .get(BAND_INDEXES_PARAM)
       .map(_.split(',').map(_.trim.toInt).toSeq)
       .getOrElse(Seq(0))
+
+    def pathTable: Option[PathColumn] = parameters
+      .get(PATH_TABLE_PARAM)
+      .zip(parameters.get(PATH_TABLE_COL_PARAM))
+      .map(p => PathColumn(p._1, p._2))
+      .headOption
   }
 }

--- a/datasource/src/main/scala/org/locationtech/rasterframes/datasource/rastersource/RasterSourceRelation.scala
+++ b/datasource/src/main/scala/org/locationtech/rasterframes/datasource/rastersource/RasterSourceRelation.scala
@@ -21,7 +21,6 @@
 
 package org.locationtech.rasterframes.datasource.rastersource
 
-<<<<<<< HEAD:datasource/src/main/scala/org/locationtech/rasterframes/datasource/rastersource/RasterSourceRelation.scala
 import org.locationtech.rasterframes._
 import org.locationtech.rasterframes.datasource.rastersource.RasterSourceRelation.bandNames
 import org.locationtech.rasterframes.encoders.CatalystSerializer._
@@ -30,24 +29,11 @@ import org.locationtech.rasterframes.util._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.apache.spark.sql.{Row, SQLContext}
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.functions._
+import org.locationtech.rasterframes.datasource.rastersource.RasterSourceDataSource.PathColumn
 import org.locationtech.rasterframes.model.TileDimensions
 import org.locationtech.rasterframes.tiles.ProjectedRasterTile
-=======
-import astraea.spark.rasterframes._
-import astraea.spark.rasterframes.datasource.rastersource.RasterSourceDataSource.PathColumn
-import astraea.spark.rasterframes.datasource.rastersource.RasterSourceRelation.bandNames
-import astraea.spark.rasterframes.encoders.CatalystSerializer._
-import astraea.spark.rasterframes.expressions.transformers.{RasterRefToTile, RasterSourceToRasterRefs, URIToRasterSource}
-import astraea.spark.rasterframes.model.TileDimensions
-import astraea.spark.rasterframes.tiles.ProjectedRasterTile
-import astraea.spark.rasterframes.util._
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.sources.{BaseRelation, TableScan}
-import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.apache.spark.sql.{DataFrame, Row, SQLContext}
-import org.apache.spark.sql.functions.col
->>>>>>> Added ability to use a RasterSourceRelation against a table/view of paths.:datasource/src/main/scala/astraea/spark/rasterframes/datasource/rastersource/RasterSourceRelation.scala
 
 /**
   * Constructs a Spark Relation over one or more RasterSource paths.

--- a/datasource/src/main/scala/org/locationtech/rasterframes/datasource/rastersource/package.scala
+++ b/datasource/src/main/scala/org/locationtech/rasterframes/datasource/rastersource/package.scala
@@ -50,10 +50,10 @@ package object rastersource {
         reader.option(RasterSourceDataSource.TILE_DIMS_PARAM, s"$cols,$rows")
       )
 
-    def fromTable(tableName: String, columnName: String): RasterSourceDataFrameReader =
+    def fromTable(tableName: String, bandColumnNames: String*): RasterSourceDataFrameReader =
       tag[RasterSourceDataFrameReaderTag][DataFrameReader](
         reader.option(RasterSourceDataSource.PATH_TABLE_PARAM, tableName)
-          .option(RasterSourceDataSource.PATH_TABLE_COL_PARAM, columnName)
+          .option(RasterSourceDataSource.PATH_TABLE_COL_PARAM, bandColumnNames.mkString(","))
       )
 
     def from(newlineDelimPaths: String): RasterSourceDataFrameReader =

--- a/datasource/src/main/scala/org/locationtech/rasterframes/datasource/rastersource/package.scala
+++ b/datasource/src/main/scala/org/locationtech/rasterframes/datasource/rastersource/package.scala
@@ -50,6 +50,12 @@ package object rastersource {
         reader.option(RasterSourceDataSource.TILE_DIMS_PARAM, s"$cols,$rows")
       )
 
+    def fromTable(tableName: String, columnName: String): RasterSourceDataFrameReader =
+      tag[RasterSourceDataFrameReaderTag][DataFrameReader](
+        reader.option(RasterSourceDataSource.PATH_TABLE_PARAM, tableName)
+          .option(RasterSourceDataSource.PATH_TABLE_COL_PARAM, columnName)
+      )
+
     def from(newlineDelimPaths: String): RasterSourceDataFrameReader =
       tag[RasterSourceDataFrameReaderTag][DataFrameReader](
         reader.option(RasterSourceDataSource.PATHS_PARAM, newlineDelimPaths)

--- a/datasource/src/test/scala/org/locationtech/rasterframes/datasource/geotiff/GeoTiffDataSourceSpec.scala
+++ b/datasource/src/test/scala/org/locationtech/rasterframes/datasource/geotiff/GeoTiffDataSourceSpec.scala
@@ -83,7 +83,7 @@ class GeoTiffDataSourceSpec
 
     it("should read in correctly check-summed contents") {
       // c.f. TileStatsSpec -> computing statistics over tiles -> should compute tile statistics -> sum
-      val rf = spark.read.geotiff.loadRF(l8samplePath)
+      val rf = spark.read.geotiff.loadRF(l8B1SamplePath)
       val expected = 309149454 // computed with rasterio
       val result = rf.agg(
         sum(tile_sum(rf("tile")))

--- a/datasource/src/test/scala/org/locationtech/rasterframes/datasource/rastersource/RasterSourceDataSourceSpec.scala
+++ b/datasource/src/test/scala/org/locationtech/rasterframes/datasource/rastersource/RasterSourceDataSourceSpec.scala
@@ -133,15 +133,17 @@ class RasterSourceDataSourceSpec extends TestEnvironment with TestData {
       val bandPaths = Seq((l8SamplePath(1).toASCIIString, l8SamplePath(2).toASCIIString, l8SamplePath(3).toASCIIString))
         .toDF("B1", "B2", "B3")
 
+      bandPaths.show()
+
       bandPaths.createOrReplaceTempView("pathsTable")
 
       val df = spark.read.rastersource
         .fromTable("pathsTable", "B1", "B2", "B3")
         .withTileDimensions(128, 128)
         .load()
+
       df.show(false)
-      df.select("path").distinct().count() should be(3)
-      df.schema.size should be(2)
+      df.schema.size should be(6)
     }
   }
 }

--- a/datasource/src/test/scala/org/locationtech/rasterframes/datasource/rastersource/RasterSourceDataSourceSpec.scala
+++ b/datasource/src/test/scala/org/locationtech/rasterframes/datasource/rastersource/RasterSourceDataSourceSpec.scala
@@ -130,10 +130,11 @@ class RasterSourceDataSourceSpec extends TestEnvironment with TestData {
 
 
     it("should read a extent coherent bands from multiple files") {
-      val bandPaths = Seq((l8SamplePath(1).toASCIIString, l8SamplePath(2).toASCIIString, l8SamplePath(3).toASCIIString))
+      val bandPaths = Seq((
+        l8SamplePath(1).toASCIIString,
+        l8SamplePath(2).toASCIIString,
+        l8SamplePath(3).toASCIIString))
         .toDF("B1", "B2", "B3")
-
-      bandPaths.show()
 
       bandPaths.createOrReplaceTempView("pathsTable")
 
@@ -142,8 +143,9 @@ class RasterSourceDataSourceSpec extends TestEnvironment with TestData {
         .withTileDimensions(128, 128)
         .load()
 
-      df.show(false)
       df.schema.size should be(6)
+      df.tileColumns.size should be (3)
+      df.select($"B1_path").distinct().count() should be (1)
     }
   }
 }


### PR DESCRIPTION
Enables the use of a prior relation (e.g. a catalog query) as (symbolic) input into the `RasterSourceRelation`. Couldn't figure out a way of providing a direct reference to a DataFrame as input to the `DataFrameReader`, so it relies on the user creating a temporary view. 

Mostly intended for chaining raster reading after a catalog query.