### PR TITLE
Feature/forall exists

### DIFF
--- a/core/src/main/scala/org/locationtech/rasterframes/RasterFunctions.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/RasterFunctions.scala
@@ -169,8 +169,15 @@ trait RasterFunctions {
   def rf_no_data_cells(tile: Column): TypedColumn[Any, Long] =
     NoDataCells(tile)
 
+  /** Returns true if all cells in the tile are NoData.*/
   def rf_is_no_data_tile(tile: Column): TypedColumn[Any, Boolean] =
     IsNoDataTile(tile)
+
+  /** Returns true if any cells in the tile are true (non-zero and not NoData). */
+  def rf_exists(tile: Column): TypedColumn[Any, Boolean] = Exists(tile)
+
+  /** Returns true if all cells in the tile are true (non-zero and not NoData). */
+  def rf_for_all(tile: Column): TypedColumn[Any, Boolean] = ForAll(tile)
 
   /** Compute cell-local aggregate descriptive statistics for a column of Tiles. */
   def rf_agg_local_stats(col: Column) =

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/package.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/package.scala
@@ -98,6 +98,8 @@ package object expressions {
     registry.registerExpression[DataCells]("rf_data_cells")
     registry.registerExpression[NoDataCells]("rf_no_data_cells")
     registry.registerExpression[IsNoDataTile]("rf_is_no_data_tile")
+    registry.registerExpression[Exists]("rf_exists")
+    registry.registerExpression[ForAll]("rf_for_all")
     registry.registerExpression[TileMin]("rf_tile_min")
     registry.registerExpression[TileMax]("rf_tile_max")
     registry.registerExpression[TileMean]("rf_tile_mean")

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/tilestats/Exists.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/tilestats/Exists.scala
@@ -1,0 +1,54 @@
+package org.locationtech.rasterframes.expressions.tilestats
+
+import geotrellis.raster.{Tile, isData}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Column, TypedColumn}
+import org.locationtech.rasterframes.expressions.UnaryRasterOp
+import org.locationtech.rasterframes.model.TileContext
+
+@ExpressionDescription(
+  usage = "_FUNC_(tile) - Returns true if any cells in the tile are true (non-zero and not nodata).",
+  arguments =
+    """
+    Arguments:
+       * tile - tile to check
+    """,
+  examples =
+    """
+    > SELECT _FUNC_(tile);
+       true
+    """
+)
+case class Exists(child: Expression) extends UnaryRasterOp with CodegenFallback {
+  override def nodeName: String = "exists"
+  override def dataType: DataType = BooleanType
+  override protected def eval(tile: Tile, ctx: Option[TileContext]): Any = Exists.op(tile)
+
+}
+
+object Exists{
+
+  def apply(tile: Column): TypedColumn[Any, Boolean] = new Column(Exists(tile.expr)).as[Boolean]
+
+  def op(tile: Tile): Boolean = {
+
+    def doubleValueIs(d: Double): Boolean =  isData(d) & d != 0.0
+    def intValueIs(i: Int): Boolean =  isData(i) & i != 0
+
+    var (c, r) = (0, 0)
+    while (r < tile.rows) {
+      while(c < tile.cols) {
+        if(tile.cellType.isFloatingPoint) { if(doubleValueIs(tile.getDouble(c, r))) return true }
+        else { if(intValueIs(tile.get(c, r))) return true }
+        c += 1
+      }
+      c = 0; r += 1
+    }
+
+    false
+  }
+
+
+}

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/tilestats/ForAll.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/tilestats/ForAll.scala
@@ -1,0 +1,54 @@
+package org.locationtech.rasterframes.expressions.tilestats
+
+import geotrellis.raster.{Tile, isData}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Column, TypedColumn}
+import org.locationtech.rasterframes.expressions.UnaryRasterOp
+import org.locationtech.rasterframes.model.TileContext
+
+@ExpressionDescription(
+  usage = "_FUNC_(tile) - Returns true if all cells in the tile are true (non-zero and not nodata).",
+  arguments =
+    """
+    Arguments:
+       * tile - tile to check
+    """,
+  examples =
+    """
+    > SELECT _FUNC_(tile);
+       true
+    """
+)
+case class ForAll(child: Expression) extends UnaryRasterOp with CodegenFallback {
+  override def nodeName: String = "for_all"
+  override def dataType: DataType = BooleanType
+  override protected def eval(tile: Tile, ctx: Option[TileContext]): Any = ForAll.op(tile)
+
+}
+
+object ForAll{
+
+  def apply(tile: Column): TypedColumn[Any, Boolean] = new Column(ForAll(tile.expr)).as[Boolean]
+
+  def op(tile: Tile): Boolean = {
+
+    def doubleValueIs(d: Double): Boolean =  isData(d) & d != 0.0
+    def intValueIs(i: Int): Boolean =  isData(i) & i != 0
+
+    var (c, r) = (0, 0)
+    while (r < tile.rows) {
+      while(c < tile.cols) {
+        if(tile.cellType.isFloatingPoint) { if(! doubleValueIs(tile.getDouble(c, r))) return false }
+        else { if(! intValueIs(tile.get(c, r))) return false }
+        c += 1
+      }
+      c = 0; r += 1
+    }
+
+    true
+  }
+
+
+}

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/tilestats/ForAll.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/tilestats/ForAll.scala
@@ -1,12 +1,14 @@
 package org.locationtech.rasterframes.expressions.tilestats
 
-import geotrellis.raster.{Tile, isData}
+import geotrellis.raster.Tile
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, TypedColumn}
+import org.locationtech.rasterframes.isCellTrue
 import org.locationtech.rasterframes.expressions.UnaryRasterOp
 import org.locationtech.rasterframes.model.TileContext
+import spire.syntax.cfor.cfor
 
 @ExpressionDescription(
   usage = "_FUNC_(tile) - Returns true if all cells in the tile are true (non-zero and not nodata).",
@@ -28,27 +30,22 @@ case class ForAll(child: Expression) extends UnaryRasterOp with CodegenFallback 
 
 }
 
-object ForAll{
+object ForAll {
+  import org.locationtech.rasterframes.encoders.StandardEncoders.PrimitiveEncoders.boolEnc
 
   def apply(tile: Column): TypedColumn[Any, Boolean] = new Column(ForAll(tile.expr)).as[Boolean]
 
   def op(tile: Tile): Boolean = {
-
-    def doubleValueIs(d: Double): Boolean =  isData(d) & d != 0.0
-    def intValueIs(i: Int): Boolean =  isData(i) & i != 0
-
-    var (c, r) = (0, 0)
-    while (r < tile.rows) {
-      while(c < tile.cols) {
-        if(tile.cellType.isFloatingPoint) { if(! doubleValueIs(tile.getDouble(c, r))) return false }
-        else { if(! intValueIs(tile.get(c, r))) return false }
-        c += 1
+    cfor(0)(_ < tile.rows, _ + 1) { r ⇒
+      cfor(0)(_ < tile.cols, _ + 1) { c ⇒
+        if (tile.cellType.isFloatingPoint) {
+          if (!isCellTrue(tile.getDouble(c, r))) return false
+        }
+        else {
+          if (!isCellTrue(tile.get(c, r))) return false
+        }
       }
-      c = 0; r += 1
     }
-
     true
   }
-
-
 }

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/tilestats/Sum.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/tilestats/Sum.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.{Column, TypedColumn}
 import org.locationtech.rasterframes.model.TileContext
 
 @ExpressionDescription(
-  usage = "_FUNC_(tile) - Computes the sum of all the cells in a tile..",
+  usage = "_FUNC_(tile) - Computes the sum of all the cells in a tile.",
   arguments = """
   Arguments:
     * tile - tile to sum up""",

--- a/core/src/main/scala/org/locationtech/rasterframes/rasterframes.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/rasterframes.scala
@@ -22,6 +22,7 @@
 package org.locationtech
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
+import geotrellis.raster.isData
 import geotrellis.raster.{Tile, TileFeature}
 import geotrellis.spark.{ContextRDD, Metadata, SpaceTimeKey, SpatialKey, TileLayerMetadata}
 import org.apache.spark.rdd.RDD
@@ -134,4 +135,9 @@ package object rasterframes extends StandardColumns
       override val selfType: TypeTag[SpaceTimeKey] = implicitly
     }
   }
+
+  /** Test if a cell value evaluates to true: it is not NoData and it is non-zero */
+  def isCellTrue(v: Double): Boolean =  isData(v) & v != 0.0
+  /** Test if a cell value evaluates to true: it is not NoData and it is non-zero */
+  def isCellTrue(v: Int): Boolean =  isData(v) & v != 0
 }

--- a/core/src/test/scala/org/locationtech/rasterframes/RasterFunctionsSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/RasterFunctionsSpec.scala
@@ -336,6 +336,22 @@ class RasterFunctionsSpec extends FunSpec
       df2.select(rf_is_no_data_tile($"not_nd")).first() should be(false)
       checkDocs("rf_is_no_data_tile")
     }
+
+    it("should evaluate exists and forall") {
+      val df0 = Seq(zero).toDF("tile")
+      df0.select(rf_exists($"tile")).first() should be(false)
+      df0.select(rf_for_all($"tile")).first() should be(false)
+
+      Seq(one).toDF("tile").select(rf_exists($"tile")).first() should be(true)
+      Seq(one).toDF("tile").select(rf_for_all($"tile")).first() should be(true)
+
+      val dfNd = Seq(TestData.injectND(1)(one)).toDF("tile")
+      dfNd.select(rf_exists($"tile")).first() should be(true)
+      dfNd.select(rf_for_all($"tile")).first() should be(false)
+
+      checkDocs("rf_exists")
+      checkDocs("rf_for_all")
+    }
     it("should find the minimum cell value") {
       val min = randNDTile.toArray().filter(c => raster.isData(c)).min.toDouble
       val df = Seq(randNDTile).toDF("rand")

--- a/core/src/test/scala/org/locationtech/rasterframes/RasterFunctionsSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/RasterFunctionsSpec.scala
@@ -337,7 +337,7 @@ class RasterFunctionsSpec extends FunSpec
       checkDocs("rf_is_no_data_tile")
     }
 
-    it("should evaluate exists and forall") {
+    it("should evaluate exists and for_all") {
       val df0 = Seq(zero).toDF("tile")
       df0.select(rf_exists($"tile")).first() should be(false)
       df0.select(rf_for_all($"tile")).first() should be(false)

--- a/docs/src/main/tut/reference.md
+++ b/docs/src/main/tut/reference.md
@@ -471,8 +471,19 @@ Return the count of nodata cells in the `tile`.
 
     Long rf_data_cells(Tile tile)
     
-
 Return the count of data cells in the `tile`.
+
+#### rf_exists
+
+    Boolean rf_exists(Tile tile)
+    
+Returns true if any cells in the tile are true (non-zero and not NoData). 
+
+#### rf_for_all
+
+    Boolean rf_for_all(Tile tile)
+
+Returns true if all cells in the tile are true (non-zero and not NoData). 
 
 #### rf_tile_stats
 

--- a/docs/src/main/tut/reference.md
+++ b/docs/src/main/tut/reference.md
@@ -229,7 +229,7 @@ Generate a `tile` with the values from `data_tile`, with nodata in cells where t
 
     Boolean rf_is_no_data_tile(Tile)
  
-Returns true if `tile` contains only nodata. By definition returns false if cell type does not support nodata.
+Returns true if `tile` contains only nodata. By definition returns false if cell type does not support nodata. To count nodata cells or data cells, see @ref:[`rf_no_data_cells`](reference.md#rf-no-data-cells), @ref:[`rf_data_cells`](reference.md#rf-data-cells), @ref:[`rf_agg_no_data_cells`](reference.md#rf-agg-no-data-cells), @ref:[`rf_agg_data_cells`](reference.md#rf-agg-data-cells), @ref:[`rf_agg_local_no_data_cells`](reference.md#rf-agg-local-no-data-cells), and @ref:[`rf_agg_local_data_cells`](reference.md#rf-agg-local-data-cells). This function is distinguished from @ref:[`rf_for_all`](reference.md#rf-for-all), which tests that values are not nodata and nonzero.
 
 #### rf_with_no_data
 
@@ -477,13 +477,13 @@ Return the count of data cells in the `tile`.
 
     Boolean rf_exists(Tile tile)
     
-Returns true if any cells in the tile are true (non-zero and not NoData). 
+Returns true if any cells in the tile are true (non-zero and not nodata). 
 
 #### rf_for_all
 
     Boolean rf_for_all(Tile tile)
 
-Returns true if all cells in the tile are true (non-zero and not NoData). 
+Returns true if all cells in the tile are true (non-zero and not nodata). See also @ref:[`rf_is_no_data_tile](reference.md#rf-is-no-data-tile), which tests that all cells are nodata.
 
 #### rf_tile_stats
 

--- a/pyrasterframes/python/pyrasterframes/rasterfunctions.py
+++ b/pyrasterframes/python/pyrasterframes/rasterfunctions.py
@@ -199,6 +199,8 @@ _rf_column_functions = {
     'rf_tile_to_array_double': 'Flattens Tile into an array of doubles.',
     'rf_cell_type': 'Extract the Tile\'s cell type',
     'rf_is_no_data_tile': 'Report if the Tile is entirely NODDATA cells',
+    'rf_exists': 'Returns true if any cells in the tile are true (non-zero and not NoData)',
+    'rf_for_all': 'Returns true if all cells in the tile are true (non-zero and not NoData).',
     'rf_agg_approx_histogram': 'Compute the full column aggregate floating point histogram',
     'rf_agg_stats': 'Compute the full column aggregate floating point statistics',
     'rf_agg_mean': 'Computes the column aggregate mean',

--- a/pyrasterframes/python/tests/PyRasterFramesTests.py
+++ b/pyrasterframes/python/tests/PyRasterFramesTests.py
@@ -120,7 +120,7 @@ class RasterFunctionsTest(unittest.TestCase):
         withRaster.show()
 
     def test_reproject(self):
-        reprojected = self.rf.withColumn('reprojected', rf_reproject_geometry('center', 'EPSG:4326', 'EPSG:3857'))
+        reprojected = self.rf.withColumn('reprojected', st_reproject('center', 'EPSG:4326', 'EPSG:3857'))
         reprojected.show()
 
     def test_aggregations(self):
@@ -224,21 +224,17 @@ class RasterFunctionsTest(unittest.TestCase):
         self.assertTrue(result == 1)  # short hand for all values are true
 
     def test_exists_for_all(self):
-        df = self.rf.withColumn('should_exist', tile_ones(5, 5, 'int8')) \
-            .withColumn('should_not_exist', tile_zeros(5, 5, 'int8'))
+        df = self.rf.withColumn('should_exist', rf_make_ones_tile(5, 5, 'int8')) \
+            .withColumn('should_not_exist', rf_make_zeros_tile(5, 5, 'int8'))
 
-        should_exist = df.select(exists(df.should_exist).alias('se')).take(1)[0].se
-        should_any = df.select(any(df.should_exist).alias('se')).take(1)[0].se
+        should_exist = df.select(rf_exists(df.should_exist).alias('se')).take(1)[0].se
         self.assertTrue(should_exist)
-        self.assertTrue(should_any)
 
-        should_not_exist = df.select(exists(df.should_not_exist).alias('se')).take(1)[0].se
-        should_not_any = df.select(any(df.should_not_exist).alias('se')).take(1)[0].se
+        should_not_exist = df.select(rf_exists(df.should_not_exist).alias('se')).take(1)[0].se
         self.assertTrue(not should_not_exist)
-        self.assertTrue(not should_not_any)
 
-        self.assertTrue(df.select(for_all(df.should_exist).alias('se')).take(1)[0].se)
-        self.assertTrue(not df.select(for_all(df.should_not_exist).alias('se')).take(1)[0].se)
+        self.assertTrue(df.select(rf_for_all(df.should_exist).alias('se')).take(1)[0].se)
+        self.assertTrue(not df.select(rf_for_all(df.should_not_exist).alias('se')).take(1)[0].se)
 
 
     def test_geomesa_pyspark(self):

--- a/pyrasterframes/python/tests/PyRasterFramesTests.py
+++ b/pyrasterframes/python/tests/PyRasterFramesTests.py
@@ -223,6 +223,23 @@ class RasterFunctionsTest(unittest.TestCase):
 
         self.assertTrue(result == 1)  # short hand for all values are true
 
+    def test_exists_for_all(self):
+        df = self.rf.withColumn('should_exist', tile_ones(5, 5, 'int8')) \
+            .withColumn('should_not_exist', tile_zeros(5, 5, 'int8'))
+
+        should_exist = df.select(exists(df.should_exist).alias('se')).take(1)[0].se
+        should_any = df.select(any(df.should_exist).alias('se')).take(1)[0].se
+        self.assertTrue(should_exist)
+        self.assertTrue(should_any)
+
+        should_not_exist = df.select(exists(df.should_not_exist).alias('se')).take(1)[0].se
+        should_not_any = df.select(any(df.should_not_exist).alias('se')).take(1)[0].se
+        self.assertTrue(not should_not_exist)
+        self.assertTrue(not should_not_any)
+
+        self.assertTrue(df.select(for_all(df.should_exist).alias('se')).take(1)[0].se)
+        self.assertTrue(not df.select(for_all(df.should_not_exist).alias('se')).take(1)[0].se)
+
 
     def test_geomesa_pyspark(self):
         from pyspark.sql.functions import lit, udf, sum

--- a/pyrasterframes/src/main/scala/org/locationtech/rasterframes/py/PyRFContext.scala
+++ b/pyrasterframes/src/main/scala/org/locationtech/rasterframes/py/PyRFContext.scala
@@ -156,7 +156,7 @@ class PyRFContext(implicit sparkSession: SparkSession) extends RasterFunctions
 
   def rf_local_unequal_int(col: Column, scalar: Int): Column = rf_local_unequal[Int](col, scalar)
 
-  def rf_reproject_geometry(geometryCol: Column, srcName: String, dstName: String): Column = {
+  def st_reproject(geometryCol: Column, srcName: String, dstName: String): Column = {
     val src = LazyCRS(srcName)
     val dst = LazyCRS(dstName)
     st_reproject(geometryCol, src, dst)


### PR DESCRIPTION
Naming of functions TBD. Considerations:

 * forall and exists are pretty common key words in scala. For scala API users if we use those terms we want the mental model of the function to match to what's happening
 * `all` is a keyword in Python
 * in numpy there are methods on arrays: `a.all()` and `a.any()` that do similar to the intent here, but with less explicit handling of nodata
 * Sometimes we prefix a column by `tile_` if the name would otherwise be pretty common (tile_sum, tile_max). Maybe this should be `tile_for_all` or `cells_for_all`?
 * Another thought: `is_no_data_tile` does something like for_all proposed here, testing the cells are all nodata. If we also had a `undefined` function; `is_no_data_tile(t)` would be equivalent to `for_all(undefined(t))`

https://s22s.myjetbrains.com/youtrack/issue/RF-18

Issue about defined / undefined : https://s22s.myjetbrains.com/youtrack/issue/AEP-328