### PR TITLE
Formally adopting Python 3 / abandon Python 2

### DIFF
--- a/docs/src/main/paradox/release-notes.md
+++ b/docs/src/main/paradox/release-notes.md
@@ -22,6 +22,7 @@
   - Revisit use of `Tile` equality since [it's more strict](https://github.com/locationtech/geotrellis/pull/2991)
   - Update `reference.conf` to use `geotrellis.raster.gdal` namespace.
   - Replace all uses of `TileDimensions` with `geotrellis.raster.Dimensions[Int]`.
+* Formally abandon support for Python 2. Python 2 is dead. Long live Python 2.
 
 ## 0.8.x
 

--- a/pyrasterframes/src/main/python/pyrasterframes/__init__.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/__init__.py
@@ -23,11 +23,9 @@ Module initialization for PyRasterFrames. This is where much of the cool stuff i
 appended to PySpark classes.
 """
 
-from __future__ import absolute_import
 from pyspark import SparkContext
 from pyspark.sql import SparkSession, DataFrame, DataFrameReader, DataFrameWriter
 from pyspark.sql.column import _to_java_column
-from geomesa_pyspark import types # <-- required to ensure Shapely UDTs get registered.
 
 # Import RasterFrameLayer types and functions
 from .rf_context import RFContext
@@ -35,10 +33,12 @@ from .version import __version__
 from .rf_types import RasterFrameLayer, TileExploder, TileUDT, RasterSourceUDT
 import geomesa_pyspark.types  # enable vector integrations
 
+from typing import Dict, Tuple, List, Optional, Union
+
 __all__ = ['RasterFrameLayer', 'TileExploder']
 
 
-def _rf_init(spark_session):
+def _rf_init(spark_session: SparkSession) -> SparkSession:
     """ Adds RasterFrames functionality to PySpark session."""
     if not hasattr(spark_session, "rasterframes"):
         spark_session.rasterframes = RFContext(spark_session)
@@ -47,7 +47,7 @@ def _rf_init(spark_session):
     return spark_session
 
 
-def _kryo_init(builder):
+def _kryo_init(builder: SparkSession.Builder) -> SparkSession.Builder:
     """Registers Kryo Serializers for better performance."""
     # NB: These methods need to be kept up-to-date wit those in `org.locationtech.rasterframes.extensions.KryoMethods`
     builder \
@@ -56,7 +56,9 @@ def _kryo_init(builder):
         .config("spark.kryoserializer.buffer.max", "500m")
     return builder
 
-def _convert_df(df, sp_key=None, metadata=None):
+
+def _convert_df(df: DataFrame, sp_key=None, metadata=None) -> RasterFrameLayer:
+    """ Internal function to convert a DataFrame to a RasterFrameLayer. """
     ctx = SparkContext._active_spark_context._rf_context
 
     if sp_key is None:
@@ -67,7 +69,10 @@ def _convert_df(df, sp_key=None, metadata=None):
             df._jdf, _to_java_column(sp_key), json.dumps(metadata)), ctx._spark_session)
 
 
-def _raster_join(df, other, left_extent=None, left_crs=None, right_extent=None, right_crs=None, join_exprs=None):
+def _raster_join(df: DataFrame, other: DataFrame,
+                 left_extent=None, left_crs=None,
+                 right_extent=None, right_crs=None,
+                 join_exprs=None) -> DataFrame:
     ctx = SparkContext._active_spark_context._rf_context
     if join_exprs is not None:
         assert left_extent is not None and left_crs is not None and right_extent is not None and right_crs is not None
@@ -86,31 +91,31 @@ def _raster_join(df, other, left_extent=None, left_crs=None, right_extent=None, 
     return RasterFrameLayer(jdf, ctx._spark_session)
 
 
-def _layer_reader(df_reader, format_key, path, **options):
+def _layer_reader(df_reader: DataFrameReader, format_key: str, path: Optional[str], **options: str) -> RasterFrameLayer:
     """ Loads the file of the given type at the given path."""
     df = df_reader.format(format_key).load(path, **options)
     return _convert_df(df)
 
 
-def _aliased_reader(df_reader, format_key, path, **options):
+def _aliased_reader(df_reader: DataFrameReader, format_key: str, path: Optional[str], **options: str) -> DataFrame:
     """ Loads the file of the given type at the given path."""
     return df_reader.format(format_key).load(path, **options)
 
 
-def _aliased_writer(df_writer, format_key, path, **options):
+def _aliased_writer(df_writer: DataFrameWriter, format_key: str, path: Optional[str], **options: str):
     """ Saves the dataframe to a file of the given type at the given path."""
     return df_writer.format(format_key).save(path, **options)
 
 
 def _raster_reader(
-        df_reader,
+        df_reader: DataFrameReader,
         source=None,
-        catalog_col_names=None,
-        band_indexes=None,
-        tile_dimensions=(256, 256),
-        lazy_tiles=True,
+        catalog_col_names: Optional[List[str]] = None,
+        band_indexes: Optional[List[int]] = None,
+        tile_dimensions: Tuple[int] = (256, 256),
+        lazy_tiles: bool = True,
         spatial_index_partitions=None,
-        **options):
+        **options: str) -> DataFrame:
     """
     Returns a Spark DataFrame from raster data files specified by URIs.
     Each row in the returned DataFrame will contain a column with struct of (CRS, Extent, Tile) for each item in
@@ -166,7 +171,7 @@ def _raster_reader(
     options.update({
         "band_indexes": to_csv(band_indexes),
         "tile_dimensions": to_csv(tile_dimensions),
-        "lazy_tiles": lazy_tiles
+        "lazy_tiles": str(lazy_tiles)
     })
 
     # Parse the `source` argument
@@ -241,19 +246,19 @@ def _raster_reader(
 
 
 def _geotiff_writer(
-    df_writer,
-    path=None,
-    crs=None,
-    raster_dimensions=None,
-    **options):
+        df_writer: DataFrameWriter,
+        path: str,
+        crs: Optional[str] = None,
+        raster_dimensions: Tuple[int] = None,
+        **options: str):
 
     def set_dims(parts):
         parts = [int(p) for p in parts]
         assert len(parts) == 2, "Expected dimensions specification to have exactly two components"
         assert all([p > 0 for p in parts]), "Expected all components in dimensions to be positive integers"
         options.update({
-            "imageWidth": parts[0],
-            "imageHeight": parts[1]
+            "imageWidth": str(parts[0]),
+            "imageHeight": str(parts[1])
         })
         parts = [int(p) for p in parts]
         assert all([p > 0 for p in parts]), 'nice message'

--- a/pyrasterframes/src/main/python/pyrasterframes/rasterfunctions.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/rasterfunctions.py
@@ -23,21 +23,38 @@ This module creates explicit Python functions that map back to the existing Scal
 implementations. Most functions are standard Column functions, but those with unique
 signatures are handled here as well.
 """
-from __future__ import absolute_import
 from pyspark.sql.column import Column, _to_java_column
 from pyspark.sql.functions import lit
 from .rf_context import RFContext
 from .rf_types import CellType
+from .version import __version__
+
+from deprecation import deprecated
+from typing import Union, List, Optional, Iterable
+from py4j.java_gateway import JavaObject
 
 THIS_MODULE = 'pyrasterframes'
 
+Column_type = Union[str, Column]
 
-def _context_call(name, *args):
+
+def _context_call(name: str, *args):
     f = RFContext.active().lookup(name)
     return f(*args)
 
 
-def _parse_cell_type(cell_type_arg):
+def _apply_column_function(name: str, *args: Column_type) -> Column:
+    jfcn = RFContext.active().lookup(name)
+    jcols = [_to_java_column(arg) for arg in args]
+    return Column(jfcn(*jcols))
+
+
+def _apply_scalar_to_tile(name: str, tile_col: Column_type, scalar: Union[int, float]) -> Column:
+    jfcn = RFContext.active().lookup(name)
+    return Column(jfcn(_to_java_column(tile_col), scalar))
+
+
+def _parse_cell_type(cell_type_arg: Union[str, CellType]) -> JavaObject:
     """ Convert the cell type representation to the expected JVM CellType object."""
 
     def to_jvm(ct):
@@ -49,12 +66,14 @@ def _parse_cell_type(cell_type_arg):
         return to_jvm(cell_type_arg.cell_type_name)
 
 
-def rf_cell_types():
+def rf_cell_types() -> List[CellType]:
     """Return a list of standard cell types"""
     return [CellType(str(ct)) for ct in _context_call('rf_cell_types')]
 
 
-def rf_assemble_tile(col_index, row_index, cell_data_col, num_cols, num_rows, cell_type=None):
+def rf_assemble_tile(col_index: Column_type, row_index: Column_type, cell_data_col: Column_type,
+                     num_cols: Union[int, Column_type], num_rows: Union[int, Column_type],
+                     cell_type: Optional[Union[str, CellType]] = None) -> Column:
     """Create a Tile from  a column of cell data with location indices"""
     jfcn = RFContext.active().lookup('rf_assemble_tile')
 
@@ -76,189 +95,275 @@ def rf_assemble_tile(col_index, row_index, cell_data_col, num_cols, num_rows, ce
             num_cols, num_rows, _parse_cell_type(cell_type)
         ))
 
-def rf_array_to_tile(array_col, num_cols, num_rows):
+
+def rf_array_to_tile(array_col: Column_type, num_cols: int, num_rows: int) -> Column:
     """Convert array in `array_col` into a Tile of dimensions `num_cols` and `num_rows'"""
     jfcn = RFContext.active().lookup('rf_array_to_tile')
     return Column(jfcn(_to_java_column(array_col), num_cols, num_rows))
 
 
-def rf_convert_cell_type(tile_col, cell_type):
+def rf_convert_cell_type(tile_col: Column_type, cell_type: Union[str, CellType]) -> Column:
     """Convert the numeric type of the Tiles in `tileCol`"""
     jfcn = RFContext.active().lookup('rf_convert_cell_type')
     return Column(jfcn(_to_java_column(tile_col), _parse_cell_type(cell_type)))
 
-def rf_interpret_cell_type_as(tile_col, cell_type):
+
+def rf_interpret_cell_type_as(tile_col: Column_type, cell_type: Union[str, CellType]) -> Column:
     """Change the interpretation of the tile_col's cell values according to specified cell_type"""
     jfcn = RFContext.active().lookup('rf_interpret_cell_type_as')
     return Column(jfcn(_to_java_column(tile_col), _parse_cell_type(cell_type)))
 
 
-def rf_make_constant_tile(scalar_value, num_cols, num_rows, cell_type=CellType.float64()):
+def rf_make_constant_tile(scalar_value: Union[int, float], num_cols: int, num_rows: int,
+                          cell_type: Union[str, CellType] = CellType.float64()) -> Column:
     """Constructor for constant tile column"""
     jfcn = RFContext.active().lookup('rf_make_constant_tile')
     return Column(jfcn(scalar_value, num_cols, num_rows, _parse_cell_type(cell_type)))
 
 
-def rf_make_zeros_tile(num_cols, num_rows, cell_type=CellType.float64()):
+def rf_make_zeros_tile(num_cols: int, num_rows: int, cell_type: Union[str, CellType] = CellType.float64()) -> Column:
     """Create column of constant tiles of zero"""
     jfcn = RFContext.active().lookup('rf_make_zeros_tile')
     return Column(jfcn(num_cols, num_rows, _parse_cell_type(cell_type)))
 
 
-def rf_make_ones_tile(num_cols, num_rows, cell_type=CellType.float64()):
+def rf_make_ones_tile(num_cols: int, num_rows: int, cell_type: Union[str, CellType] = CellType.float64()) -> Column:
     """Create column of constant tiles of one"""
     jfcn = RFContext.active().lookup('rf_make_ones_tile')
     return Column(jfcn(num_cols, num_rows, _parse_cell_type(cell_type)))
 
 
-def rf_rasterize(geometry_col, bounds_col, value_col, num_cols_col, num_rows_col):
+def rf_rasterize(geometry_col: Column_type, bounds_col: Column_type, value_col: Column_type, num_cols_col: Column_type,
+                 num_rows_col: Column_type) -> Column:
     """Create a tile where cells in the grid defined by cols, rows, and bounds are filled with the given value."""
-    jfcn = RFContext.active().lookup('rf_rasterize')
-    return Column(jfcn(_to_java_column(geometry_col), _to_java_column(bounds_col),
-                       _to_java_column(value_col), _to_java_column(num_cols_col),  _to_java_column(num_rows_col)))
+    return _apply_column_function('rf_rasterize', geometry_col, bounds_col, value_col, num_cols_col, num_rows_col)
 
 
-def st_reproject(geometry_col, src_crs, dst_crs):
+def st_reproject(geometry_col: Column_type, src_crs: Column_type, dst_crs: Column_type) -> Column:
     """Reproject a column of geometry given the CRSs of the source and destination."""
-    jfcn = RFContext.active().lookup('st_reproject')
-    return Column(jfcn(_to_java_column(geometry_col), _to_java_column(src_crs), _to_java_column(dst_crs)))
+    return _apply_column_function('st_reproject', geometry_col, src_crs, dst_crs)
 
 
-def rf_explode_tiles(*tile_cols):
+def rf_explode_tiles(*tile_cols: Column_type) -> Column:
     """Create a row for each cell in Tile."""
     jfcn = RFContext.active().lookup('rf_explode_tiles')
     jcols = [_to_java_column(arg) for arg in tile_cols]
     return Column(jfcn(RFContext.active().list_to_seq(jcols)))
 
 
-def rf_explode_tiles_sample(sample_frac, seed, *tile_cols):
+def rf_explode_tiles_sample(sample_frac: float, seed: int, *tile_cols: Column_type) -> Column:
     """Create a row for a sample of cells in Tile columns."""
     jfcn = RFContext.active().lookup('rf_explode_tiles_sample')
     jcols = [_to_java_column(arg) for arg in tile_cols]
     return Column(jfcn(sample_frac, seed, RFContext.active().list_to_seq(jcols)))
 
 
-def _apply_scalar_to_tile(name, tile_col, scalar):
-    jfcn = RFContext.active().lookup(name)
-    return Column(jfcn(_to_java_column(tile_col), scalar))
-
-
-def rf_with_no_data(tile_col, scalar):
+def rf_with_no_data(tile_col: Column_type, scalar: Union[int, float]) -> Column:
     """Assign a `NoData` value to the Tiles in the given Column."""
     return _apply_scalar_to_tile('rf_with_no_data', tile_col, scalar)
 
 
-def rf_local_add_double(tile_col, scalar):
+def rf_local_add(left_tile_col: Column_type, rhs: Union[float, int, Column_type]) -> Column:
+    """Add two Tiles, or  add a scalar to a Tile"""
+    if isinstance(rhs, (float, int)):
+        rhs = lit(rhs)
+    return _apply_column_function('rf_local_add', left_tile_col, rhs)
+
+
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
+def rf_local_add_double(tile_col: Column_type, scalar: float) -> Column:
     """Add a floating point scalar to a Tile"""
     return _apply_scalar_to_tile('rf_local_add_double', tile_col, scalar)
 
 
-def rf_local_add_int(tile_col, scalar):
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
+def rf_local_add_int(tile_col, scalar) -> Column:
     """Add an integral scalar to a Tile"""
     return _apply_scalar_to_tile('rf_local_add_int', tile_col, scalar)
 
 
+def rf_local_subtract(left_tile_col: Column_type, rhs: Union[float, int, Column_type]) -> Column:
+    """Subtract two Tiles, or subtract a scalar from a Tile"""
+    if isinstance(rhs, (float, int)):
+        rhs = lit(rhs)
+    return _apply_column_function('rf_local_subtract', left_tile_col, rhs)
+
+
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_subtract_double(tile_col, scalar):
     """Subtract a floating point scalar from a Tile"""
     return _apply_scalar_to_tile('rf_local_subtract_double', tile_col, scalar)
 
 
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_subtract_int(tile_col, scalar):
     """Subtract an integral scalar from a Tile"""
     return _apply_scalar_to_tile('rf_local_subtract_int', tile_col, scalar)
 
 
+def rf_local_multiply(left_tile_col: Column_type, rhs: Union[float, int, Column_type]) -> Column:
+    """Multiply two Tiles cell-wise, or multiply Tile cells by a scalar"""
+    if isinstance(rhs, (float, int)):
+        rhs = lit(rhs)
+    return _apply_column_function('rf_local_multiply', left_tile_col, rhs)
+
+
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_multiply_double(tile_col, scalar):
     """Multiply a Tile by a float point scalar"""
     return _apply_scalar_to_tile('rf_local_multiply_double', tile_col, scalar)
 
 
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_multiply_int(tile_col, scalar):
     """Multiply a Tile by an integral scalar"""
     return _apply_scalar_to_tile('rf_local_multiply_int', tile_col, scalar)
 
 
+def rf_local_divide(left_tile_col: Column_type, rhs: Union[float, int, Column_type]) -> Column:
+    """Divide two Tiles cell-wise, or divide a Tile's cell values by a scalar"""
+    if isinstance(rhs, (float, int)):
+        rhs = lit(rhs)
+    return _apply_column_function('rf_local_divide', left_tile_col, rhs)
+
+
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_divide_double(tile_col, scalar):
     """Divide a Tile by a floating point scalar"""
     return _apply_scalar_to_tile('rf_local_divide_double', tile_col, scalar)
 
 
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_divide_int(tile_col, scalar):
     """Divide a Tile by an integral scalar"""
     return _apply_scalar_to_tile('rf_local_divide_int', tile_col, scalar)
 
 
+def rf_local_less(left_tile_col: Column_type, rhs: Union[float, int, Column_type]) -> Column:
+    """Cellwise less than comparison between two tiles, or with a scalar value"""
+    if isinstance(rhs, (float, int)):
+        rhs = lit(rhs)
+    return _apply_column_function('rf_local_less', left_tile_col, rhs)
+
+
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_less_double(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is less than a scalar, otherwise 0"""
     return _apply_scalar_to_tile('foo', tile_col, scalar)
 
 
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_less_int(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is less than a scalar, otherwise 0"""
     return _apply_scalar_to_tile('rf_local_less_double', tile_col, scalar)
 
 
+def rf_local_less_equal(left_tile_col: Column_type, rhs: Union[float, int, Column_type]) -> Column:
+    """Cellwise less than or equal to comparison between two tiles, or with a scalar value"""
+    if isinstance(rhs, (float, int)):
+        rhs = lit(rhs)
+    return _apply_column_function('rf_local_less_equal', left_tile_col, rhs)
+
+
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_less_equal_double(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is less than or equal to a scalar, otherwise 0"""
     return _apply_scalar_to_tile('rf_local_less_equal_double', tile_col, scalar)
 
 
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_less_equal_int(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is less than or equal to a scalar, otherwise 0"""
     return _apply_scalar_to_tile('rf_local_less_equal_int', tile_col, scalar)
 
 
+def rf_local_greater(left_tile_col: Column, rhs: Union[float, int, Column_type]) -> Column:
+    """Cellwise greater than comparison between two tiles, or with a scalar value"""
+    if isinstance(rhs, (float, int)):
+        rhs = lit(rhs)
+    return _apply_column_function('rf_local_greater', left_tile_col, rhs)
+
+
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_greater_double(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is greater than a scalar, otherwise 0"""
     return _apply_scalar_to_tile('rf_local_greater_double', tile_col, scalar)
 
 
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_greater_int(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is greater than a scalar, otherwise 0"""
     return _apply_scalar_to_tile('rf_local_greater_int', tile_col, scalar)
 
 
+def rf_local_greater_equal(left_tile_col: Column, rhs: Union[float, int, Column_type]) -> Column:
+    """Cellwise greater than or equal to comparison between two tiles, or with a scalar value"""
+    if isinstance(rhs, (float, int)):
+        rhs = lit(rhs)
+    return _apply_column_function('rf_local_greater_equal', left_tile_col, rhs)
+
+
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_greater_equal_double(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is greater than or equal to a scalar, otherwise 0"""
     return _apply_scalar_to_tile('rf_local_greater_equal_double', tile_col, scalar)
 
 
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_greater_equal_int(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is greater than or equal to a scalar, otherwise 0"""
     return _apply_scalar_to_tile('rf_local_greater_equal_int', tile_col, scalar)
 
 
+def rf_local_equal(left_tile_col, rhs: Union[float, int, Column_type]) -> Column:
+    """Cellwise equality comparison between two tiles, or with a scalar value"""
+    if isinstance(rhs, (float, int)):
+        rhs = lit(rhs)
+    return _apply_column_function('rf_local_equal', left_tile_col, rhs)
+
+
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_equal_double(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is equal to a scalar, otherwise 0"""
     return _apply_scalar_to_tile('rf_local_equal_double', tile_col, scalar)
 
 
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_equal_int(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is equal to a scalar, otherwise 0"""
     return _apply_scalar_to_tile('rf_local_equal_int', tile_col, scalar)
 
 
+def rf_local_unequal(left_tile_col, rhs: Union[float, int, Column_type]) -> Column:
+    """Cellwise inequality comparison between two tiles, or with a scalar value"""
+    if isinstance(rhs, (float, int)):
+        rhs = lit(rhs)
+    return _apply_column_function('rf_local_unequal', left_tile_col, rhs)
+
+
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_unequal_double(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is not equal to a scalar, otherwise 0"""
     return _apply_scalar_to_tile('rf_local_unequal_double', tile_col, scalar)
 
 
+@deprecated(deprecated_in='0.9.0', removed_in='1.0.0', current_version=__version__)
 def rf_local_unequal_int(tile_col, scalar):
     """Return a Tile with values equal 1 if the cell is not equal to a scalar, otherwise 0"""
     return _apply_scalar_to_tile('rf_local_unequal_int', tile_col, scalar)
 
 
-def rf_local_no_data(tile_col):
+def rf_local_no_data(tile_col: Column_type) -> Column:
     """Return a tile with ones where the input is NoData, otherwise zero."""
     return _apply_column_function('rf_local_no_data', tile_col)
 
 
-def rf_local_data(tile_col):
+def rf_local_data(tile_col: Column_type) -> Column:
     """Return a tile with zeros where the input is NoData, otherwise one."""
     return _apply_column_function('rf_local_data', tile_col)
 
 
-def rf_local_is_in(tile_col, array):
+def rf_local_is_in(tile_col: Column_type, array: Union[Column_type, List]) -> Column:
     """Return a tile with cell values of 1 where the `tile_col` cell is in the provided array."""
     from pyspark.sql.functions import array as sql_array
     if isinstance(array, list):
@@ -267,188 +372,162 @@ def rf_local_is_in(tile_col, array):
     return _apply_column_function('rf_local_is_in', tile_col, array)
 
 
-def _apply_column_function(name, *args):
-    jfcn = RFContext.active().lookup(name)
-    jcols = [_to_java_column(arg) for arg in args]
-    return Column(jfcn(*jcols))
-
-
-def rf_dimensions(tile_col):
+def rf_dimensions(tile_col: Column_type) -> Column:
     """Query the number of (cols, rows) in a Tile."""
     return _apply_column_function('rf_dimensions', tile_col)
 
 
-def rf_tile_to_array_int(tile_col):
+def rf_tile_to_array_int(tile_col: Column_type) -> Column:
     """Flattens Tile into an array of integers."""
     return _apply_column_function('rf_tile_to_array_int', tile_col)
 
 
-def rf_tile_to_array_double(tile_col):
+def rf_tile_to_array_double(tile_col: Column_type) -> Column:
     """Flattens Tile into an array of doubles."""
     return _apply_column_function('rf_tile_to_array_double', tile_col)
 
 
-def rf_cell_type(tile_col):
+def rf_cell_type(tile_col: Column_type) -> Column:
     """Extract the Tile's cell type"""
     return _apply_column_function('rf_cell_type', tile_col)
 
 
-def rf_is_no_data_tile(tile_col):
+def rf_is_no_data_tile(tile_col: Column_type) -> Column:
     """Report if the Tile is entirely NODDATA cells"""
     return _apply_column_function('rf_is_no_data_tile', tile_col)
 
 
-def rf_exists(tile_col):
+def rf_exists(tile_col: Column_type) -> Column:
     """Returns true if any cells in the tile are true (non-zero and not NoData)"""
     return _apply_column_function('rf_exists', tile_col)
 
 
-def rf_for_all(tile_col):
+def rf_for_all(tile_col: Column_type) -> Column:
     """Returns true if all cells in the tile are true (non-zero and not NoData)."""
     return _apply_column_function('rf_for_all', tile_col)
 
 
-def rf_agg_approx_histogram(tile_col):
+def rf_agg_approx_histogram(tile_col: Column_type) -> Column:
     """Compute the full column aggregate floating point histogram"""
     return _apply_column_function('rf_agg_approx_histogram', tile_col)
 
 
-def rf_agg_stats(tile_col):
+def rf_agg_stats(tile_col: Column_type) -> Column:
     """Compute the full column aggregate floating point statistics"""
     return _apply_column_function('rf_agg_stats', tile_col)
 
 
-def rf_agg_mean(tile_col):
+def rf_agg_mean(tile_col: Column_type) -> Column:
     """Computes the column aggregate mean"""
     return _apply_column_function('rf_agg_mean', tile_col)
 
 
-def rf_agg_data_cells(tile_col):
+def rf_agg_data_cells(tile_col: Column_type) -> Column:
     """Computes the number of non-NoData cells in a column"""
     return _apply_column_function('rf_agg_data_cells', tile_col)
 
 
-def rf_agg_no_data_cells(tile_col):
+def rf_agg_no_data_cells(tile_col: Column_type) -> Column:
     """Computes the number of NoData cells in a column"""
     return _apply_column_function('rf_agg_no_data_cells', tile_col)
 
 
-def rf_tile_histogram(tile_col):
+def rf_tile_histogram(tile_col: Column_type) -> Column:
     """Compute the Tile-wise histogram"""
     return _apply_column_function('rf_tile_histogram', tile_col)
 
 
-def rf_tile_mean(tile_col):
+def rf_tile_mean(tile_col: Column_type) -> Column:
     """Compute the Tile-wise mean"""
     return _apply_column_function('rf_tile_mean', tile_col)
 
 
-def rf_tile_sum(tile_col):
+def rf_tile_sum(tile_col: Column_type) -> Column:
     """Compute the Tile-wise sum"""
     return _apply_column_function('rf_tile_sum', tile_col)
 
 
-def rf_tile_min(tile_col):
+def rf_tile_min(tile_col: Column_type) -> Column:
     """Compute the Tile-wise minimum"""
     return _apply_column_function('rf_tile_min', tile_col)
 
 
-def rf_tile_max(tile_col):
+def rf_tile_max(tile_col: Column_type) -> Column:
     """Compute the Tile-wise maximum"""
     return _apply_column_function('rf_tile_max', tile_col)
 
 
-def rf_tile_stats(tile_col):
+def rf_tile_stats(tile_col: Column_type) -> Column:
     """Compute the Tile-wise floating point statistics"""
     return _apply_column_function('rf_tile_stats', tile_col)
 
 
-def rf_render_ascii(tile_col):
+def rf_render_ascii(tile_col: Column_type) -> Column:
     """Render ASCII art of tile"""
     return _apply_column_function('rf_render_ascii', tile_col)
 
 
-def rf_render_matrix(tile_col):
+def rf_render_matrix(tile_col: Column_type) -> Column:
     """Render Tile cell values as numeric values, for debugging purposes"""
     return _apply_column_function('rf_render_matrix', tile_col)
 
 
-def rf_render_png(red_tile_col, green_tile_col, blue_tile_col):
+def rf_render_png(red_tile_col: Column_type, green_tile_col: Column_type, blue_tile_col: Column_type) -> Column:
     """Converts columns of tiles representing RGB channels into a PNG encoded byte array."""
     return _apply_column_function('rf_render_png', red_tile_col, green_tile_col, blue_tile_col)
 
 
-def rf_rgb_composite(red_tile_col, green_tile_col, blue_tile_col):
+def rf_rgb_composite(red_tile_col: Column_type, green_tile_col: Column_type, blue_tile_col: Column_type) -> Column:
     """Converts columns of tiles representing RGB channels into a single RGB packaged tile."""
     return _apply_column_function('rf_rgb_composite', red_tile_col, green_tile_col, blue_tile_col)
 
 
-def rf_no_data_cells(tile_col):
+def rf_no_data_cells(tile_col: Column_type) -> Column:
     """Count of NODATA cells"""
     return _apply_column_function('rf_no_data_cells', tile_col)
 
 
-def rf_data_cells(tile_col):
+def rf_data_cells(tile_col: Column_type) -> Column:
     """Count of cells with valid data"""
     return _apply_column_function('rf_data_cells', tile_col)
 
 
-def rf_local_add(left_tile_col, right_tile_col):
-    """Add two Tiles"""
-    return _apply_column_function('rf_local_add', left_tile_col, right_tile_col)
-
-
-def rf_local_subtract(left_tile_col, right_tile_col):
-    """Subtract two Tiles"""
-    return _apply_column_function('rf_local_subtract', left_tile_col, right_tile_col)
-
-
-def rf_local_multiply(left_tile_col, right_tile_col):
-    """Multiply two Tiles"""
-    return _apply_column_function('rf_local_multiply', left_tile_col, right_tile_col)
-
-
-def rf_local_divide(left_tile_col, right_tile_col):
-    """Divide two Tiles"""
-    return _apply_column_function('rf_local_divide', left_tile_col, right_tile_col)
-
-
-def rf_normalized_difference(left_tile_col, right_tile_col):
+def rf_normalized_difference(left_tile_col: Column_type, right_tile_col: Column_type) -> Column:
     """Compute the normalized difference of two tiles"""
     return _apply_column_function('rf_normalized_difference', left_tile_col, right_tile_col)
 
 
-def rf_agg_local_max(tile_col):
+def rf_agg_local_max(tile_col: Column_type) -> Column:
     """Compute the cell-wise/local max operation between Tiles in a column."""
     return _apply_column_function('rf_agg_local_max', tile_col)
 
 
-def rf_agg_local_min(tile_col):
+def rf_agg_local_min(tile_col: Column_type) -> Column:
     """Compute the cellwise/local min operation between Tiles in a column."""
     return _apply_column_function('rf_agg_local_min', tile_col)
 
 
-def rf_agg_local_mean(tile_col):
+def rf_agg_local_mean(tile_col: Column_type) -> Column:
     """Compute the cellwise/local mean operation between Tiles in a column."""
     return _apply_column_function('rf_agg_local_mean', tile_col)
 
 
-def rf_agg_local_data_cells(tile_col):
+def rf_agg_local_data_cells(tile_col: Column_type) -> Column:
     """Compute the cellwise/local count of non-NoData cells for all Tiles in a column."""
     return _apply_column_function('rf_agg_local_data_cells', tile_col)
 
 
-def rf_agg_local_no_data_cells(tile_col):
+def rf_agg_local_no_data_cells(tile_col: Column_type) -> Column:
     """Compute the cellwise/local count of NoData cells for all Tiles in a column."""
     return _apply_column_function('rf_agg_local_no_data_cells', tile_col)
 
 
-def rf_agg_local_stats(tile_col):
+def rf_agg_local_stats(tile_col: Column_type) -> Column:
     """Compute cell-local aggregate descriptive statistics for a column of Tiles."""
     return _apply_column_function('rf_agg_local_stats', tile_col)
 
 
-def rf_mask(src_tile_col, mask_tile_col, inverse=False):
+def rf_mask(src_tile_col: Column_type, mask_tile_col: Column_type, inverse: bool = False) -> Column:
     """Where the rf_mask (second) tile contains NODATA, replace values in the source (first) tile with NODATA.
        If `inverse` is true, replaces values in the source tile with NODATA where the mask tile contains valid data.
     """
@@ -458,13 +537,14 @@ def rf_mask(src_tile_col, mask_tile_col, inverse=False):
         rf_inverse_mask(src_tile_col, mask_tile_col)
 
 
-def rf_inverse_mask(src_tile_col, mask_tile_col):
+def rf_inverse_mask(src_tile_col: Column_type, mask_tile_col: Column_type) -> Column:
     """Where the rf_mask (second) tile DOES NOT contain NODATA, replace values in the source
        (first) tile with NODATA."""
     return _apply_column_function('rf_inverse_mask', src_tile_col, mask_tile_col)
 
 
-def rf_mask_by_value(data_tile, mask_tile, mask_value, inverse=False):
+def rf_mask_by_value(data_tile: Column_type, mask_tile: Column_type, mask_value: Union[int, float, Column_type],
+                     inverse: bool = False) -> Column:
     """Generate a tile with the values from the data tile, but where cells in the masking tile contain the masking
     value, replace the data value with NODATA. """
     if isinstance(mask_value, (int, float)):
@@ -474,7 +554,8 @@ def rf_mask_by_value(data_tile, mask_tile, mask_value, inverse=False):
     return Column(jfcn(_to_java_column(data_tile), _to_java_column(mask_tile), _to_java_column(mask_value), inverse))
 
 
-def rf_mask_by_values(data_tile, mask_tile, mask_values):
+def rf_mask_by_values(data_tile: Column_type, mask_tile: Column_type,
+                      mask_values: Union[List[Union[int, float]], Column_type]) -> Column:
     """Generate a tile with the values from `data_tile`, but where cells in the `mask_tile` are in the `mask_values`
        list, replace the value with NODATA.
     """
@@ -487,7 +568,8 @@ def rf_mask_by_values(data_tile, mask_tile, mask_values):
     return Column(jfcn(*col_args))
 
 
-def rf_inverse_mask_by_value(data_tile, mask_tile, mask_value):
+def rf_inverse_mask_by_value(data_tile: Column_type, mask_tile: Column_type,
+                             mask_value: Union[int, float, Column_type]) -> Column:
     """Generate a tile with the values from the data tile, but where cells in the masking tile do not contain the
     masking value, replace the data value with NODATA. """
     if isinstance(mask_value, (int, float)):
@@ -495,7 +577,9 @@ def rf_inverse_mask_by_value(data_tile, mask_tile, mask_value):
     return _apply_column_function('rf_inverse_mask_by_value', data_tile, mask_tile, mask_value)
 
 
-def rf_mask_by_bit(data_tile, mask_tile, bit_position, value_to_mask):
+def rf_mask_by_bit(data_tile: Column_type, mask_tile: Column_type,
+                   bit_position: Union[int, Column_type],
+                   value_to_mask: Union[int, float, bool, Column_type]) -> Column:
     """Applies a mask using bit values in the `mask_tile`. Working from the right, extract the bit at `bitPosition` from the `maskTile`. In all locations where these are equal to the `valueToMask`, the returned tile is set to NoData, else the original `dataTile` cell value."""
     if isinstance(bit_position, int):
         bit_position = lit(bit_position)
@@ -504,7 +588,9 @@ def rf_mask_by_bit(data_tile, mask_tile, bit_position, value_to_mask):
     return _apply_column_function('rf_mask_by_bit', data_tile, mask_tile, bit_position, value_to_mask)
 
 
-def rf_mask_by_bits(data_tile, mask_tile, start_bit, num_bits, values_to_mask):
+def rf_mask_by_bits(data_tile: Column_type, mask_tile: Column_type, start_bit: Union[int, Column_type],
+                    num_bits: Union[int, Column_type],
+                    values_to_mask: Union[Iterable[Union[int, float]], Column_type]) -> Column:
     """Applies a mask from blacklisted bit values in the `mask_tile`. Working from the right, the bits from `start_bit` to `start_bit + num_bits` are @ref:[extracted](reference.md#rf_local_extract_bits) from cell values of the `mask_tile`. In all locations where these are in the `mask_values`, the returned tile is set to NoData; otherwise the original `tile` cell value is returned."""
     if isinstance(start_bit, int):
         start_bit = lit(start_bit)
@@ -517,145 +603,118 @@ def rf_mask_by_bits(data_tile, mask_tile, start_bit, num_bits, values_to_mask):
     return _apply_column_function('rf_mask_by_bits', data_tile, mask_tile, start_bit, num_bits, values_to_mask)
 
 
-def rf_local_extract_bits(tile, start_bit, num_bits=1):
+def rf_local_extract_bits(tile: Column_type, start_bit: Union[int, Column_type],
+                          num_bits: Union[int, Column_type] = 1) -> Column:
     """Extract value from specified bits of the cells' underlying binary data.
     * `startBit` is the first bit to consider, working from the right. It is zero indexed.
     * `numBits` is the number of bits to take moving further to the left. """
     if isinstance(start_bit, int):
-        start_bit = lit(bit_position)
+        start_bit = lit(start_bit)
     if isinstance(num_bits, int):
         num_bits = lit(num_bits)
     return _apply_column_function('rf_local_extract_bits', tile, start_bit, num_bits)
 
 
-def rf_local_less(left_tile_col, right_tile_col):
-    """Cellwise less than comparison between two tiles"""
-    return _apply_column_function('rf_local_less', left_tile_col, right_tile_col)
-
-
-def rf_local_less_equal(left_tile_col, right_tile_col):
-    """Cellwise less than or equal to comparison between two tiles"""
-    return _apply_column_function('rf_local_less_equal', left_tile_col, right_tile_col)
-
-
-def rf_local_greater(left_tile_col, right_tile_col):
-    """Cellwise greater than comparison between two tiles"""
-    return _apply_column_function('rf_local_greater', left_tile_col, right_tile_col)
-
-
-def rf_local_greater_equal(left_tile_col, right_tile_col):
-    """Cellwise greater than or equal to comparison between two tiles"""
-    return _apply_column_function('rf_local_greater_equal', left_tile_col, right_tile_col)
-
-
-def rf_local_equal(left_tile_col, right_tile_col):
-    """Cellwise equality comparison between two tiles"""
-    return _apply_column_function('rf_local_equal', left_tile_col, right_tile_col)
-
-
-def rf_local_unequal(left_tile_col, right_tile_col):
-    """Cellwise inequality comparison between two tiles"""
-    return _apply_column_function('rf_local_unequal', left_tile_col, right_tile_col)
-
-
-def rf_round(tile_col):
+def rf_round(tile_col: Column_type) -> Column:
     """Round cell values to the nearest integer without changing the cell type"""
     return _apply_column_function('rf_round', tile_col)
 
 
-def rf_abs(tile_col):
+def rf_abs(tile_col: Column_type) -> Column:
     """Compute the absolute value of each cell"""
     return _apply_column_function('rf_abs', tile_col)
 
 
-def rf_log(tile_col):
+def rf_log(tile_col: Column_type) -> Column:
     """Performs cell-wise natural logarithm"""
     return _apply_column_function('rf_log', tile_col)
 
 
-def rf_log10(tile_col):
+def rf_log10(tile_col: Column_type) -> Column:
     """Performs cell-wise logartithm with base 10"""
     return _apply_column_function('rf_log10', tile_col)
 
 
-def rf_log2(tile_col):
+def rf_log2(tile_col: Column_type) -> Column:
     """Performs cell-wise logartithm with base 2"""
     return _apply_column_function('rf_log2', tile_col)
 
 
-def rf_log1p(tile_col):
+def rf_log1p(tile_col: Column_type) -> Column:
     """Performs natural logarithm of cell values plus one"""
     return _apply_column_function('rf_log1p', tile_col)
 
 
-def rf_exp(tile_col):
+def rf_exp(tile_col: Column_type) -> Column:
     """Performs cell-wise exponential"""
     return _apply_column_function('rf_exp', tile_col)
 
 
-def rf_exp2(tile_col):
+def rf_exp2(tile_col: Column_type) -> Column:
     """Compute 2 to the power of cell values"""
     return _apply_column_function('rf_exp2', tile_col)
 
 
-def rf_exp10(tile_col):
+def rf_exp10(tile_col: Column_type) -> Column:
     """Compute 10 to the power of cell values"""
     return _apply_column_function('rf_exp10', tile_col)
 
 
-def rf_expm1(tile_col):
+def rf_expm1(tile_col: Column_type) -> Column:
     """Performs cell-wise exponential, then subtract one"""
     return _apply_column_function('rf_expm1', tile_col)
 
 
-def rf_identity(tile_col):
+def rf_identity(tile_col: Column_type) -> Column:
     """Pass tile through unchanged"""
     return _apply_column_function('rf_identity', tile_col)
 
 
-def rf_resample(tile_col, scale_factor_col):
+def rf_resample(tile_col: Column_type, scale_factor: Union[int, float, Column_type]) -> Column:
     """Resample tile to different size based on scalar factor or tile whose dimension to match
     Scalar less than one will downsample tile; greater than one will upsample. Uses nearest-neighbor."""
-    return _apply_column_function('rf_resample', tile_col, scale_factor_col)
+    if isinstance(scale_factor, (int, float)):
+        scale_factor = lit(scale_factor)
+    return _apply_column_function('rf_resample', tile_col, scale_factor)
 
 
-def rf_crs(tile_col):
+def rf_crs(tile_col: Column_type) -> Column:
     """Get the CRS of a RasterSource or ProjectedRasterTile"""
     return _apply_column_function('rf_crs', tile_col)
 
 
-def rf_mk_crs(crs_text):
+def rf_mk_crs(crs_text: str) -> Column:
     """Resolve CRS from text identifier. Supported registries are EPSG, ESRI, WORLD, NAD83, & NAD27.
     An example of a valid CRS name is EPSG:3005."""
     return Column(_context_call('_make_crs_literal', crs_text))
 
 
-def st_extent(geom_col):
+def st_extent(geom_col: Column_type) -> Column:
     """Compute the extent/bbox of a Geometry (a tile with embedded extent and CRS)"""
     return _apply_column_function('st_extent', geom_col)
 
 
-def rf_extent(proj_raster_col):
+def rf_extent(proj_raster_col: Column_type) -> Column:
     """Get the extent of a RasterSource or ProjectedRasterTile (a tile with embedded extent and CRS)"""
     return _apply_column_function('rf_extent', proj_raster_col)
 
 
-def rf_tile(proj_raster_col):
+def rf_tile(proj_raster_col: Column_type) -> Column:
     """Extracts the Tile component of a ProjectedRasterTile (or Tile)."""
     return _apply_column_function('rf_tile', proj_raster_col)
 
 
-def st_geometry(geom_col):
+def st_geometry(geom_col: Column_type) -> Column:
     """Convert the given extent/bbox to a polygon"""
     return _apply_column_function('st_geometry', geom_col)
 
 
-def rf_geometry(proj_raster_col):
+def rf_geometry(proj_raster_col: Column_type) -> Column:
     """Get the extent of a RasterSource or ProjectdRasterTile as a Geometry"""
     return _apply_column_function('rf_geometry', proj_raster_col)
 
 
-def rf_xz2_index(geom_col, crs_col=None, index_resolution = 18):
+def rf_xz2_index(geom_col: Column_type, crs_col: Optional[Column_type] = None, index_resolution: int = 18) -> Column:
     """Constructs a XZ2 index in WGS84 from either a Geometry, Extent, ProjectedRasterTile, or RasterSource and its CRS.
        For details: https://www.geomesa.org/documentation/user/datastores/index_overview.html """
 
@@ -666,7 +725,8 @@ def rf_xz2_index(geom_col, crs_col=None, index_resolution = 18):
     else:
         return Column(jfcn(_to_java_column(geom_col), index_resolution))
 
-def rf_z2_index(geom_col, crs_col=None, index_resolution = 18):
+
+def rf_z2_index(geom_col: Column_type, crs_col: Optional[Column_type] = None, index_resolution: int = 18) -> Column:
     """Constructs a Z2 index in WGS84 from either a Geometry, Extent, ProjectedRasterTile, or RasterSource and its CRS.
         First the native extent is extracted or computed, and then center is used as the indexing location.
         For details: https://www.geomesa.org/documentation/user/datastores/index_overview.html """

--- a/pyrasterframes/src/main/python/pyrasterframes/rf_context.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/rf_context.py
@@ -23,6 +23,11 @@ This module contains access to the jvm SparkContext with RasterFrameLayer suppor
 """
 
 from pyspark import SparkContext
+from pyspark.sql import SparkSession
+
+from typing import Any, List
+from py4j.java_gateway import JavaMember
+from py4j.java_collections import JavaList, JavaMap
 
 __all__ = ['RFContext']
 
@@ -31,21 +36,21 @@ class RFContext(object):
     """
     Entrypoint to RasterFrames services
     """
-    def __init__(self, spark_session):
+    def __init__(self, spark_session: SparkSession):
         self._spark_session = spark_session
         self._gateway = spark_session.sparkContext._gateway
         self._jvm = self._gateway.jvm
         jsess = self._spark_session._jsparkSession
         self._jrfctx = self._jvm.org.locationtech.rasterframes.py.PyRFContext(jsess)
 
-    def list_to_seq(self, py_list):
+    def list_to_seq(self, py_list: List[Any]) -> JavaList:
         conv = self.lookup('_listToSeq')
         return conv(py_list)
 
-    def lookup(self, function_name):
+    def lookup(self, function_name: str) -> JavaMember:
         return getattr(self._jrfctx, function_name)
 
-    def build_info(self):
+    def build_info(self) -> JavaMap:
         return self._jrfctx.buildInfo()
 
     # NB: Tightly coupled to `org.locationtech.rasterframes.py.PyRFContext._resolveRasterRef`

--- a/pyrasterframes/src/main/python/pyrasterframes/rf_ipython.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/rf_ipython.py
@@ -19,12 +19,16 @@
 #
 
 import pyrasterframes.rf_types
+from pyrasterframes.rf_types import Tile
 from shapely.geometry.base import BaseGeometry
-
+import matplotlib.axes.Axes
 import numpy as np
+from pandas import DataFrame
+from typing import Optional, Tuple
 
 
-def plot_tile(tile, normalize=True, lower_percentile=1, upper_percentile=99, axis=None, **imshow_args):
+def plot_tile(tile: Tile, normalize: bool = True, lower_percentile: float = 1., upper_percentile: float = 99.,
+              axis: Optional[matplotlib.axis.Axes] = None, **imshow_args):
     """
     Display an image of the tile
 
@@ -50,7 +54,7 @@ def plot_tile(tile, normalize=True, lower_percentile=1, upper_percentile=99, axi
 
     arr = tile.cells
 
-    def normalize_cells(cells):
+    def normalize_cells(cells: np.ndarray) -> np.ndarray:
         assert upper_percentile > lower_percentile, 'invalid upper and lower percentiles {}, {}'.format(lower_percentile, upper_percentile)
         sans_mask = np.array(cells)
         lower = np.nanpercentile(sans_mask, lower_percentile)
@@ -72,7 +76,8 @@ def plot_tile(tile, normalize=True, lower_percentile=1, upper_percentile=99, axi
     return axis
 
 
-def tile_to_png(tile, lower_percentile=1, upper_percentile=99, title=None, fig_size=None):
+def tile_to_png(tile: Tile, lower_percentile: float = 1., upper_percentile: float = 99., title: Optional[str] = None,
+                fig_size: Optional[Tuple[int, int]] = None) -> bytes:
     """ Provide image of Tile."""
     if tile.cells is None:
         return None
@@ -106,7 +111,7 @@ def tile_to_png(tile, lower_percentile=1, upper_percentile=99, title=None, fig_s
         return output.getvalue()
 
 
-def tile_to_html(tile, fig_size=None):
+def tile_to_html(tile: Tile, fig_size: Optional[Tuple[int, int]] = None) -> str:
     """ Provide HTML string representation of Tile image."""
     import base64
     b64_img_html = '<img src="data:image/png;base64,{}" />'
@@ -115,7 +120,7 @@ def tile_to_html(tile, fig_size=None):
     return b64_img_html.format(b64_png)
 
 
-def pandas_df_to_html(df):
+def pandas_df_to_html(df: DataFrame) -> str:
     """Provide HTML formatting for pandas.DataFrame with rf_types.Tile in the columns.  """
     import pandas as pd
     # honor the existing options on display
@@ -170,17 +175,17 @@ def pandas_df_to_html(df):
     return return_html
 
 
-def spark_df_to_markdown(df, num_rows=5, truncate=False):
+def spark_df_to_markdown(df: DataFrame, num_rows: int = 5, truncate: bool = False) -> str:
     from pyrasterframes import RFContext
     return RFContext.active().call("_dfToMarkdown", df._jdf, num_rows, truncate)
 
 
-def spark_df_to_html(df, num_rows=5, truncate=False):
+def spark_df_to_html(df: DataFrame, num_rows: int = 5, truncate: bool = False) -> str:
     from pyrasterframes import RFContext
     return RFContext.active().call("_dfToHTML", df._jdf, num_rows, truncate)
 
 
-def _folium_map_formatter(map):
+def _folium_map_formatter(map) -> str:
     """ inputs a folium.Map object and returns html of rendered map """
     
     import base64

--- a/pyrasterframes/src/main/python/pyrasterframes/rf_types.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/rf_types.py
@@ -34,18 +34,22 @@ from pyspark.ml.wrapper import JavaTransformer
 from pyspark.ml.util import DefaultParamsReadable, DefaultParamsWritable
 
 from pyrasterframes.rf_context import RFContext
+from pyspark.sql import SparkSession
+from py4j.java_collections import Sequence
 
 import numpy as np
+
+from typing import List, Tuple
 
 __all__ = ['RasterFrameLayer', 'Tile', 'TileUDT', 'CellType', 'RasterSourceUDT', 'TileExploder', 'NoDataFilter']
 
 
 class RasterFrameLayer(DataFrame):
-    def __init__(self, jdf, spark_session):
+    def __init__(self, jdf: DataFrame, spark_session: SparkSession):
         DataFrame.__init__(self, jdf, spark_session._wrapped)
         self._jrfctx = spark_session.rasterframes._jrfctx
 
-    def tile_columns(self):
+    def tile_columns(self) -> List[Column]:
         """
         Fetches columns of type Tile.
         :return: One or more Column instances associated with Tiles.
@@ -53,7 +57,7 @@ class RasterFrameLayer(DataFrame):
         cols = self._jrfctx.tileColumns(self._jdf)
         return [Column(c) for c in cols]
 
-    def spatial_key_column(self):
+    def spatial_key_column(self) -> Column:
         """
         Fetch the tagged spatial key column.
         :return: Spatial key column
@@ -61,7 +65,7 @@ class RasterFrameLayer(DataFrame):
         col = self._jrfctx.spatialKeyColumn(self._jdf)
         return Column(col)
 
-    def temporal_key_column(self):
+    def temporal_key_column(self) -> Column:
         """
         Fetch the temporal key column, if any.
         :return: Temporal key column, or None.
@@ -77,7 +81,7 @@ class RasterFrameLayer(DataFrame):
         import json
         return json.loads(str(self._jrfctx.tileLayerMetadata(self._jdf)))
 
-    def spatial_join(self, other_df):
+    def spatial_join(self, other_df: DataFrame):
         """
         Spatially join this RasterFrameLayer to the given RasterFrameLayer.
         :return: Joined RasterFrameLayer.
@@ -86,7 +90,7 @@ class RasterFrameLayer(DataFrame):
         df = ctx._jrfctx.spatialJoin(self._jdf, other_df._jdf)
         return RasterFrameLayer(df, ctx._spark_session)
 
-    def to_int_raster(self, colname, cols, rows):
+    def to_int_raster(self, colname: str, cols: int, rows: int) -> Sequence:
         """
         Convert a tile to an Int raster
         :return: array containing values of the tile's cells
@@ -94,7 +98,7 @@ class RasterFrameLayer(DataFrame):
         resArr = self._jrfctx.toIntRaster(self._jdf, colname, cols, rows)
         return resArr
 
-    def to_double_raster(self, colname, cols, rows):
+    def to_double_raster(self, colname: str, cols: int, rows: int) -> Sequence:
         """
         Convert a tile to an Double raster
         :return: array containing values of the tile's cells
@@ -170,7 +174,7 @@ class CellType(object):
         self.cell_type_name = cell_type_name
 
     @classmethod
-    def from_numpy_dtype(cls, np_dtype):
+    def from_numpy_dtype(cls, np_dtype: np.dtype):
         return CellType(str(np_dtype.name))
 
     @classmethod
@@ -205,19 +209,19 @@ class CellType(object):
     def float64(cls):
         return CellType('float64')
 
-    def is_raw(self):
+    def is_raw(self) -> bool:
         return self.cell_type_name.endswith('raw')
 
-    def is_user_defined_no_data(self):
+    def is_user_defined_no_data(self) -> bool:
         return "ud" in self.cell_type_name
 
-    def is_default_no_data(self):
+    def is_default_no_data(self) -> bool:
         return not (self.is_raw() or self.is_user_defined_no_data())
 
-    def is_floating_point(self):
+    def is_floating_point(self) -> bool:
         return self.cell_type_name.startswith('float')
 
-    def base_cell_type_name(self):
+    def base_cell_type_name(self) -> str:
         if self.is_raw():
             return self.cell_type_name[:-3]
         elif self.is_user_defined_no_data():
@@ -225,7 +229,7 @@ class CellType(object):
         else:
             return self.cell_type_name
 
-    def has_no_data(self):
+    def has_no_data(self) -> bool:
         return not self.is_raw()
 
     def no_data_value(self):
@@ -254,7 +258,7 @@ class CellType(object):
                     return None
         raise Exception("Unable to determine no_data_value from '{}'".format(n))
 
-    def to_numpy_dtype(self):
+    def to_numpy_dtype(self) -> np.dtype:
         n = self.base_cell_type_name()
         return np.dtype(n).newbyteorder('>')
 
@@ -354,7 +358,7 @@ class Tile(object):
             other = right
         return Tile(np.matmul(self.cells, other))
 
-    def dimensions(self):
+    def dimensions(self) -> Tuple[int, int]:
         """ Return a list of cols, rows as is conventional in GeoTrellis and RasterFrames."""
         return [self.cells.shape[1], self.cells.shape[0]]
 

--- a/pyrasterframes/src/main/python/pyrasterframes/version.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/version.py
@@ -20,4 +20,4 @@
 #
 
 # Translating Java version from version.sbt to PEP440 norms
-__version__ = '0.9.0.dev0'
+__version__: str = '0.9.0.dev0'

--- a/pyrasterframes/src/main/python/setup.py
+++ b/pyrasterframes/src/main/python/setup.py
@@ -57,7 +57,6 @@ class PweaveDocs(distutils.cmd.Command):
         ('quick=', 'q', 'Check to see if the source file is newer than existing output before building. Defaults to `False`.')
     ]
 
-
     def initialize_options(self):
         """Set default values for options."""
         # Each user option must be listed here with their default value.
@@ -149,6 +148,7 @@ folium = 'folium'
 pytest = 'pytest>=4.0.0,<5.0.0'
 pypandoc = 'pypandoc'
 boto3 = 'boto3'
+deprecation = 'deprecation'
 
 setup(
     name='pyrasterframes',
@@ -188,7 +188,8 @@ setup(
         pweave,
         fiona,
         rasterio,
-        folium
+        folium,
+        deprecation
     ],
     tests_require=[
         pytest,
@@ -218,7 +219,7 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Operating System :: Unix',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries',
         'Topic :: Scientific/Engineering :: GIS',
         'Topic :: Multimedia :: Graphics :: Graphics Conversion',

--- a/pyrasterframes/src/main/python/tests/PyRasterFramesTests.py
+++ b/pyrasterframes/src/main/python/tests/PyRasterFramesTests.py
@@ -326,9 +326,7 @@ class TileOps(TestEnvironment):
         self.assertTrue(np.array_equal(r2, np.array([[1,1], [1, 1]], dtype=r2.dtype)))
 
     def test_matmul(self):
-        # if sys.version >= '3.5':  # per https://docs.python.org/3.7/library/operator.html#operator.matmul new in 3.5
-        #     r1 = self.t1 @ self.t2
-        r1 = self.t1.__matmul__(self.t2)
+        r1 = self.t1 @ self.t2
 
         # The behavior of np.matmul with masked arrays is not well documented
         # it seems to treat the 2nd arg as if not a MaskedArray

--- a/pyrasterframes/src/main/python/tests/RasterFunctionsTests.py
+++ b/pyrasterframes/src/main/python/tests/RasterFunctionsTests.py
@@ -26,6 +26,7 @@ from pyspark.sql.functions import *
 
 import numpy as np
 from numpy.testing import assert_equal
+from deprecation import fail_if_not_removed
 
 from unittest import skip
 from . import TestEnvironment
@@ -132,6 +133,12 @@ class RasterFunctions(TestEnvironment):
         self.assertEqual(row['rf_agg_data_cells(tile)'], 387000)
         self.assertEqual(row['rf_agg_no_data_cells(tile)'], 1000)
         self.assertEqual(row['rf_agg_stats(tile)'].data_cells, row['rf_agg_data_cells(tile)'])
+
+    @fail_if_not_removed
+    def test_add_scalar(self):
+        # Trivial test to trigger the deprecation failure at the right time.
+        result: Row = self.rf.select(rf_local_add_double('tile', 99.9), rf_local_add_int('tile', 42)).first()
+        self.assertTrue(True)
 
     def test_sql(self):
 

--- a/pyrasterframes/src/main/python/tests/__init__.py
+++ b/pyrasterframes/src/main/python/tests/__init__.py
@@ -18,20 +18,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-import glob
 import os
 import unittest
 
 from pyrasterframes.utils import create_rf_spark_session
 
-import sys
 
-if sys.version_info[0] > 2:
-    import builtins
-else:
-    import __builtin__ as builtins
+import builtins
 
 app_name = 'pyrasterframes test suite'
+
 
 def resource_dir():
     def pdir(curr):


### PR DESCRIPTION
Release notes
Type hints in many user facing parts of the API
Removing awkward if sys.version < 3 stuff
Deprecating some of the `f(l: Column, r: float)` and `f(l: Column, r: int)` functions in favor of a more general `f(l: Column, r: Union[float, int, Column])` signature

It seems like we were a good deal of the way towards python 3 already.