### PR TITLE
Fix circle build gdal 244

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ _defaults: &defaults
   environment:
     TERM: dumb
   docker:
-    - image: s22s/rasterframes-circleci:9b7682ef
+    - image: s22s/rasterframes-circleci:fdb3f763
 
 _setenv: &setenv
   name: set CloudRepo credentials

--- a/build/circleci/Dockerfile
+++ b/build/circleci/Dockerfile
@@ -1,7 +1,7 @@
 FROM circleci/openjdk:8-jdk
 
 ENV OPENJPEG_VERSION 2.3.1
-ENV GDAL_VERSION 2.4.1
+ENV GDAL_VERSION 2.4.4
 ENV SPATIALINDEX_VERSION 1.9.3
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 


### PR DESCRIPTION
tests jobs have been failing since python libraries bumped to GDAL 2.4.4. Circle container was still on 2.4.1 